### PR TITLE
docs: 修正 API 相关文档编辑此页链接的错误引用

### DIFF
--- a/public/api-en-US.md
+++ b/public/api-en-US.md
@@ -2247,8 +2247,4 @@ Example: [Add XSS extension](https://imzbf.github.io/md-editor-rt/en-US/demo#%F0
 
 ## ✍️ Edit This Page
 
-[doc-en-US](https://github.com/imzbf/md-editor-rt/blob/dev-docs/public/doc-en-US.md)
-
-```
-
-```
+[doc-en-US](https://github.com/imzbf/md-editor-rt/blob/dev-docs/public/api-en-US.md)

--- a/public/api-zh-CN.md
+++ b/public/api-zh-CN.md
@@ -2287,4 +2287,4 @@ clearSideEffects();
 
 ## ✍️ 编辑此页面
 
-[doc-zh-CN](https://github.com/imzbf/md-editor-rt/blob/dev-docs/public/doc-zh-CN.md)
+[doc-zh-CN](https://github.com/imzbf/md-editor-rt/blob/dev-docs/public/api-zh-CN.md)


### PR DESCRIPTION
如题，[API 文档的 —— `Edit This Page`](https://imzbf.github.io/md-editor-rt/en-US/api#%E2%9C%8D%EF%B8%8F%20Edit%20This%20Page) 存在链接引用错误问题。

此 `pull request` 已尝试修复