### PR TITLE
docs: 补充 contrast-zh-CN.md 中相较于 contrast-en-US.md 缺失的 Catalog 组件描述

### DIFF
--- a/public/contrast-zh-CN.md
+++ b/public/contrast-zh-CN.md
@@ -265,3 +265,11 @@ MdEditor.config({
 | katexJs             | 同上                              |
 | katexCss            | 同上                              |
 | extensions          | 同上                              |
+
+### 组件
+
+- Catalog
+
+  `Editor.Catalog` 已重命名为 `Editor.MdCatalog`.
+
+  更多用法，请查阅 [docs](https://github.com/imzbf/md-editor-rt/tree/docs).


### PR DESCRIPTION
### Component

- Catalog

  `Editor.Catalog` is renamed to `Editor.MdCatalog`.

  For more usage, refer to branch [docs](https://github.com/imzbf/md-editor-rt/tree/docs).

↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑
为中文文档添加此英文内容的对应部分

中文文档新增内容：
↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓

### 组件

- Catalog

  `Editor.Catalog` 已重命名为 `Editor.MdCatalog`.

  更多用法，请查阅 [docs](https://github.com/imzbf/md-editor-rt/tree/docs).
