### PR TITLE
Add ARIA labels to toolbar buttons

### DIFF
--- a/packages/DropdownToolbar/index.tsx
+++ b/packages/DropdownToolbar/index.tsx
@@ -33,6 +33,7 @@ const DropdownToolbar = (props: DropdownToolbarProps) => {
       <button
         className={className}
         title={props.title || ''}
+        aria-label={props.title || ''}
         disabled={props.disabled}
         type="button"
       >

--- a/packages/MdEditor/layouts/Toolbar/tools/Bold.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Bold.tsx
@@ -18,6 +18,7 @@ const ToolbarBold = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.bold}
+      aria-label={ult.toolbarTips?.bold}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'bold');

--- a/packages/MdEditor/layouts/Toolbar/tools/Catalog.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Catalog.tsx
@@ -23,6 +23,7 @@ const ToolbarCatalog = () => {
         disabled && `${prefix}-disabled`
       ])}
       title={ult.toolbarTips?.catalog}
+      aria-label={ult.toolbarTips?.catalog}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, CHANGE_CATALOG_VISIBLE);

--- a/packages/MdEditor/layouts/Toolbar/tools/Code.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Code.tsx
@@ -18,6 +18,7 @@ const ToolbarCode = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.code}
+      aria-label={ult.toolbarTips?.code}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'code');

--- a/packages/MdEditor/layouts/Toolbar/tools/CodeRow.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/CodeRow.tsx
@@ -18,6 +18,7 @@ const ToolbarCodeRow = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.codeRow}
+      aria-label={ult.toolbarTips?.codeRow}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'codeRow');

--- a/packages/MdEditor/layouts/Toolbar/tools/Fullscreen.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Fullscreen.tsx
@@ -24,6 +24,7 @@ const ToolbarFullscreen = () => {
         disabled && `${prefix}-disabled`
       ])}
       title={ult.toolbarTips?.fullscreen}
+      aria-label={ult.toolbarTips?.fullscreen}
       disabled={disabled}
       onClick={() => {
         fullscreenHandler();

--- a/packages/MdEditor/layouts/Toolbar/tools/Github.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Github.tsx
@@ -12,6 +12,7 @@ const ToolbarGithub = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.github}
+      aria-label={ult.toolbarTips?.github}
       disabled={disabled}
       onClick={() => {
         linkTo('https://github.com/imzbf/md-editor-rt');

--- a/packages/MdEditor/layouts/Toolbar/tools/HtmlPreview.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/HtmlPreview.tsx
@@ -21,6 +21,7 @@ const ToolbarHtmlPreview = () => {
         disabled && `${prefix}-disabled`
       ])}
       title={ult.toolbarTips?.htmlPreview}
+      aria-label={ult.toolbarTips?.htmlPreview}
       disabled={disabled}
       onClick={() => {
         updateSetting('htmlPreview');

--- a/packages/MdEditor/layouts/Toolbar/tools/Image.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Image.tsx
@@ -18,6 +18,7 @@ const ToolbarImage = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.image}
+      aria-label={ult.toolbarTips?.image}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'image');

--- a/packages/MdEditor/layouts/Toolbar/tools/ImageDropdown.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/ImageDropdown.tsx
@@ -115,6 +115,7 @@ const ToolbarImageDropdown = () => {
           disabled && `${prefix}-disabled`
         ])}
         title={ult.toolbarTips?.image}
+        aria-label={ult.toolbarTips?.image}
         disabled={disabled}
         type="button"
       >

--- a/packages/MdEditor/layouts/Toolbar/tools/Italic.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Italic.tsx
@@ -18,6 +18,7 @@ const ToolbarItalic = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.italic}
+      aria-label={ult.toolbarTips?.italic}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'italic');

--- a/packages/MdEditor/layouts/Toolbar/tools/Katex.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Katex.tsx
@@ -68,6 +68,7 @@ const ToolbarKatex = () => {
           disabled && `${prefix}-disabled`
         ])}
         title={ult.toolbarTips?.katex}
+        aria-label={ult.toolbarTips?.katex}
         disabled={disabled}
         type="button"
       >

--- a/packages/MdEditor/layouts/Toolbar/tools/Link.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Link.tsx
@@ -18,6 +18,7 @@ const ToolbarLink = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.link}
+      aria-label={ult.toolbarTips?.link}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'link');

--- a/packages/MdEditor/layouts/Toolbar/tools/Mermaid.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Mermaid.tsx
@@ -138,6 +138,7 @@ const ToolbarMermaid = () => {
           disabled && `${prefix}-disabled`
         ])}
         title={ult.toolbarTips?.mermaid}
+        aria-label={ult.toolbarTips?.mermaid}
         disabled={disabled}
         type="button"
       >

--- a/packages/MdEditor/layouts/Toolbar/tools/Next.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Next.tsx
@@ -18,6 +18,7 @@ const ToolbarNext = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.next}
+      aria-label={ult.toolbarTips?.next}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, CTRL_SHIFT_Z);

--- a/packages/MdEditor/layouts/Toolbar/tools/OrderedList.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/OrderedList.tsx
@@ -18,6 +18,7 @@ const ToolbarOrderedList = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.orderedList}
+      aria-label={ult.toolbarTips?.orderedList}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'orderedList');

--- a/packages/MdEditor/layouts/Toolbar/tools/PageFullscreen.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/PageFullscreen.tsx
@@ -21,6 +21,7 @@ const ToolbarPageFullscreen = () => {
         disabled && `${prefix}-disabled`
       ])}
       title={ult.toolbarTips?.pageFullscreen}
+      aria-label={ult.toolbarTips?.pageFullscreen}
       disabled={disabled}
       onClick={() => {
         updateSetting('pageFullscreen');

--- a/packages/MdEditor/layouts/Toolbar/tools/Prettier.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Prettier.tsx
@@ -18,6 +18,7 @@ const ToolbarPrettier = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.prettier}
+      aria-label={ult.toolbarTips?.prettier}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'prettier');

--- a/packages/MdEditor/layouts/Toolbar/tools/Preview.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Preview.tsx
@@ -21,6 +21,7 @@ const ToolbarPreview = () => {
         disabled && `${prefix}-disabled`
       ])}
       title={ult.toolbarTips?.preview}
+      aria-label={ult.toolbarTips?.preview}
       disabled={disabled}
       onClick={() => {
         updateSetting('preview');

--- a/packages/MdEditor/layouts/Toolbar/tools/PreviewOnly.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/PreviewOnly.tsx
@@ -21,6 +21,7 @@ const ToolbarPreviewOnly = () => {
         disabled && `${prefix}-disabled`
       ])}
       title={ult.toolbarTips?.previewOnly}
+      aria-label={ult.toolbarTips?.previewOnly}
       disabled={disabled}
       onClick={() => {
         updateSetting('previewOnly');

--- a/packages/MdEditor/layouts/Toolbar/tools/Quote.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Quote.tsx
@@ -18,6 +18,7 @@ const ToolbarQuote = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.quote}
+      aria-label={ult.toolbarTips?.quote}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'quote');

--- a/packages/MdEditor/layouts/Toolbar/tools/Revoke.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Revoke.tsx
@@ -18,6 +18,7 @@ const ToolbarRevoke = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.revoke}
+      aria-label={ult.toolbarTips?.revoke}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, CTRL_Z);

--- a/packages/MdEditor/layouts/Toolbar/tools/Save.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Save.tsx
@@ -18,6 +18,7 @@ const ToolbarSave = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.save}
+      aria-label={ult.toolbarTips?.save}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, ON_SAVE);

--- a/packages/MdEditor/layouts/Toolbar/tools/StrikeThrough.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/StrikeThrough.tsx
@@ -18,6 +18,7 @@ const ToolbarStrikeThrough = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.strikeThrough}
+      aria-label={ult.toolbarTips?.strikeThrough}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'strikeThrough');

--- a/packages/MdEditor/layouts/Toolbar/tools/Sub.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Sub.tsx
@@ -18,6 +18,7 @@ const ToolbarSub = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.sub}
+      aria-label={ult.toolbarTips?.sub}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'sub');

--- a/packages/MdEditor/layouts/Toolbar/tools/Sup.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Sup.tsx
@@ -18,6 +18,7 @@ const ToolbarSup = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.sup}
+      aria-label={ult.toolbarTips?.sup}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'sup');

--- a/packages/MdEditor/layouts/Toolbar/tools/Table.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Table.tsx
@@ -39,6 +39,7 @@ const ToolbarTable = () => {
           disabled && `${prefix}-disabled`
         ])}
         title={ult.toolbarTips?.table}
+        aria-label={ult.toolbarTips?.table}
         disabled={disabled}
         type="button"
       >

--- a/packages/MdEditor/layouts/Toolbar/tools/Task.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Task.tsx
@@ -18,6 +18,7 @@ const ToolbarTask = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.task}
+      aria-label={ult.toolbarTips?.task}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'task');

--- a/packages/MdEditor/layouts/Toolbar/tools/Title.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Title.tsx
@@ -116,6 +116,7 @@ const ToolbarTitle = () => {
         ])}
         disabled={disabled}
         title={ult.toolbarTips?.title}
+        aria-label={ult.toolbarTips?.title}
         type="button"
       >
         <Icon name="title" />

--- a/packages/MdEditor/layouts/Toolbar/tools/Underline.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/Underline.tsx
@@ -18,6 +18,7 @@ const ToolbarUnderline = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.underline}
+      aria-label={ult.toolbarTips?.underline}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'underline');

--- a/packages/MdEditor/layouts/Toolbar/tools/UnorderedList.tsx
+++ b/packages/MdEditor/layouts/Toolbar/tools/UnorderedList.tsx
@@ -18,6 +18,7 @@ const ToolbarUnorderedList = () => {
     <button
       className={classnames([`${prefix}-toolbar-item`, disabled && `${prefix}-disabled`])}
       title={ult.toolbarTips?.unorderedList}
+      aria-label={ult.toolbarTips?.unorderedList}
       disabled={disabled}
       onClick={() => {
         bus.emit(editorId, REPLACE, 'unorderedList');

--- a/packages/ModalToolbar/index.tsx
+++ b/packages/ModalToolbar/index.tsx
@@ -37,7 +37,8 @@ const ModalToolbar = (props: ModalToolbarProps) => {
     <>
       <button
         className={`${prefix}-toolbar-item${props.disabled ? ' ' + prefix + '-disabled' : ''}`}
-        title={props.title}
+        title={props.title || ''}
+        aria-label={props.title || ''}
         onClick={(e) => {
           props.onClick(e);
         }}

--- a/packages/NormalToolbar/index.tsx
+++ b/packages/NormalToolbar/index.tsx
@@ -20,7 +20,8 @@ const NormalToolbar = (props: NormalToolbarProps) => {
   return (
     <button
       className={className}
-      title={props.title}
+      title={props.title || ''}
+      aria-label={props.title || ''}
       onClick={(e) => {
         if (props.disabled) return;
         props.onClick(e);


### PR DESCRIPTION
This PR adds `aria-label` attributes to the built‑in toolbar buttons and toolbar wrapper components so screen readers announce the controls. It does not change button behavior or visual styling.